### PR TITLE
[TASK] Add composer dump-autoload for deployment

### DIFF
--- a/Classes/Lightwerk/SurfRunner/Domain/Model/Application/DeployApplication.php
+++ b/Classes/Lightwerk/SurfRunner/Domain/Model/Application/DeployApplication.php
@@ -35,6 +35,7 @@ class DeployApplication extends AbstractApplication {
 		'package' => array(
 			'typo3.surf:package:git',
 			'typo3.surf:composer:install',
+			'typo3.surf:composer:dumpAutoload',
 			'lightwerk.surftasks:git:clean',
 			'lightwerk.surftasks:assets:npm',
 			'lightwerk.surftasks:assets:bower',
@@ -69,6 +70,13 @@ class DeployApplication extends AbstractApplication {
 			'options' => array(
 				'nodeName' => 'localhost',
 				'composerCommandPath' => 'composer',
+			),
+		),
+		'typo3.surf:composer:dumpAutoload' => array(
+			'options' => array(
+				'nodeName' => 'localhost',
+				'composerCommandPath' => 'composer',
+				'composerArguments' => '--optimize',
 			),
 		),
 		'lightwerk.surftasks:git:tagnodedeployment' => array(

--- a/Classes/Lightwerk/SurfRunner/Domain/Model/Application/TYPO3/CMS/DeployApplication.php
+++ b/Classes/Lightwerk/SurfRunner/Domain/Model/Application/TYPO3/CMS/DeployApplication.php
@@ -37,6 +37,7 @@ class DeployApplication extends AbstractApplication {
 		'package' => array(
 			'typo3.surf:package:git',
 			'typo3.surf:composer:install',
+			'typo3.surf:composer:dumpAutoload',
 			'lightwerk.surftasks:git:clean',
 			'lightwerk.surftasks:assets:npm',
 			'lightwerk.surftasks:assets:bower',
@@ -79,6 +80,13 @@ class DeployApplication extends AbstractApplication {
 			'options' => array(
 				'nodeName' => 'localhost',
 				'composerCommandPath' => 'composer',
+			),
+		),
+		'typo3.surf:composer:dumpAutoload' => array(
+			'options' => array(
+				'nodeName' => 'localhost',
+				'composerCommandPath' => 'composer',
+				'composerArguments' => '--optimize',
 			),
 		),
 		'lightwerk.surftasks:git:clean' => array(

--- a/Classes/Lightwerk/SurfRunner/Domain/Model/Application/TYPO3/Flow/DeployApplication.php
+++ b/Classes/Lightwerk/SurfRunner/Domain/Model/Application/TYPO3/Flow/DeployApplication.php
@@ -26,6 +26,7 @@ class DeployApplication extends AbstractApplication {
 		'package' => array(
 			'typo3.surf:package:git',
 			'typo3.surf:composer:install',
+			'typo3.surf:composer:dumpAutoload',
 			'lightwerk.surftasks:git:clean',
 			'lightwerk.surftasks:assets:gulp',
 		),
@@ -59,6 +60,13 @@ class DeployApplication extends AbstractApplication {
 			'options' => array(
 				'nodeName' => 'localhost',
 				'composerCommandPath' => 'composer',
+			),
+		),
+		'typo3.surf:composer:dumpAutoload' => array(
+			'options' => array(
+				'nodeName' => 'localhost',
+				'composerCommandPath' => 'composer',
+				'composerArguments' => '--optimize',
 			),
 		),
 		'lightwerk.surftasks:transfer:rsync' => array(


### PR DESCRIPTION
Dumps the autoload. (composer dump-autoload --optimize)

composer.json

```
{
    "autoload": {
        "psr-4": {
            "Namespace\\ExtKey\\": "typo3conf/ext/ext_key/Classes"
        }
    }
}
```

See: https://github.com/TYPO3/Surf/pull/30
